### PR TITLE
Optimize the newsfeeds fanout

### DIFF
--- a/friendships/services.py
+++ b/friendships/services.py
@@ -34,4 +34,9 @@ class FriendshipService(object):
     def invalidate_following_cache(cls, from_user_id):
         key = FOLLOWINGS_PATTERN.format(user_id=from_user_id)
         cache.delete(key)
+
+    @classmethod
+    def get_follower_ids(cls, user_id):
+        friendships = Friendship.objects.filter(to_user_id=user_id)
+        return [friendship.from_user_id for friendship in friendships]
         

--- a/newsfeeds/constants.py
+++ b/newsfeeds/constants.py
@@ -1,0 +1,3 @@
+from django.conf import settings
+
+FANOUT_BATCH_SIZE = 1000 if not settings.TESTING else 3

--- a/newsfeeds/services.py
+++ b/newsfeeds/services.py
@@ -1,5 +1,5 @@
 from newsfeeds.models import Newsfeed
-from newsfeeds.tasks import fanout_newsfeeds_task
+from newsfeeds.tasks import fanout_newsfeeds_main_task
 from twitter.cache import USER_NEWSFEEDS_PATTERN
 from util.redis_helper import RedisHelper
 
@@ -7,7 +7,7 @@ from util.redis_helper import RedisHelper
 class NewsfeedService(object):
     @classmethod
     def fanout_to_followers(cls, tweet):
-        fanout_newsfeeds_task.delay(tweet.id)
+        fanout_newsfeeds_main_task.delay(tweet.id, tweet.user_id)
 
     @classmethod
     def get_cached_newsfeeds(cls, user_id):

--- a/newsfeeds/tasks.py
+++ b/newsfeeds/tasks.py
@@ -1,22 +1,40 @@
 from celery import shared_task
+from friendships.services import FriendshipService
+from newsfeeds.constants import FANOUT_BATCH_SIZE
 from newsfeeds.models import Newsfeed
-from tweets.models import Tweet
 from util.time_constants import ONE_HOUR
 
 
-@shared_task(time_limit=ONE_HOUR)
-def fanout_newsfeeds_task(tweet_id):
-    from friendships.services import FriendshipService
+@shared_task(routing_key='default', time_limit=ONE_HOUR)
+def fanout_newsfeeds_main_task(tweet_id, tweet_user_id):
+    # First insert the newsfeed to the tweet's owner
+    Newsfeed.objects.create(user_id=tweet_user_id, tweet_id=tweet_id)
+
+    follower_ids = FriendshipService.get_follower_ids(tweet_user_id)
+    index = 0
+    while index < len(follower_ids):
+        batch_ids = follower_ids[index: index + FANOUT_BATCH_SIZE]
+        fanout_newsfeeds_batch_task(tweet_id, batch_ids)
+        index += FANOUT_BATCH_SIZE
+
+    return '{} newsfeeds going to fanout, {} batches created.'.format(
+        len(follower_ids),
+        (len(follower_ids) - 1) // FANOUT_BATCH_SIZE + 1
+    )
+
+
+@shared_task(routing_key='newsfeeds', time_limit=ONE_HOUR)
+def fanout_newsfeeds_batch_task(tweet_id, follower_ids):
     from newsfeeds.services import NewsfeedService
 
-    tweet = Tweet.objects.filter(id=tweet_id)
-    user = tweet.user
-    followers = FriendshipService.get_followers(user)
-    newsfeeds = [Newsfeed(user=follower, tweet=tweet) for follower in followers]
-    # add tweet's owner since it is visible to the owner themself
-    newsfeeds.append(Newsfeed(user=tweet.user, tweet=tweet))
+    newsfeeds = [
+        Newsfeed(user_id=follower_id, tweet_id=tweet_id)
+        for follower_id in follower_ids
+    ]
     Newsfeed.objects.bulk_create(newsfeeds)
 
     # bulk create doesn't trigger post_save, so load to cache manually
     for newsfeed in newsfeeds:
         NewsfeedService.push_newsfeed_to_cache(newsfeed)
+
+    return '{} newsfeeds created'.format(len(newsfeeds))

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
+from kombu import Queue
 from pathlib import Path
 import os
 import sys
@@ -182,6 +183,21 @@ REDIS_LIST_LENGTH_LIMIT = 200 if not TESTING else 20
 CELERY_BROKER_URL = 'redis://127.0.0.1:6379/2' if not TESTING else 'redis://127.0.0.1:6379/0'
 CELERY_TIMEZONE = "UTC"
 CELERY_TASK_ALWAYS_EAGER = TESTING
+#  Split queues to distinguish main tasks and the small batch task
+CELERY_QUEUES = (
+    Queue('default', routing_key='default'),
+    Queue('newsfeeds', routing_key='newsfeeds'),
+)
+
+# Set different queues to different workers
+# if os.environ.get('WORKER_TYPE') == 'newsfeed':
+#     CELERY_QUEUES = (
+#         Queue('newsfeeds', routing_key='newsfeeds'),
+#     )
+# else:
+#     CELERY_QUEUES = (
+#         Queue('default', routing_key='default'),
+#     )
 
 try:
     from .local_settings import *


### PR DESCRIPTION
1. Add a main task to split the fanout in batches.
2. Split queues for the main task and the batch task.